### PR TITLE
Fix: add Falcon key remap and KV-only compatibility

### DIFF
--- a/origin_progressive_serve/progressive_for_causal_lm.py
+++ b/origin_progressive_serve/progressive_for_causal_lm.py
@@ -339,6 +339,29 @@ class ProgressiveForCausalLM(nn.Module):
                     loaded_keys.add(param_name)
                     loaded_count += 1
                     continue
+
+            # Option 5: Falcon HuggingFace 형식 변환
+            # vLLM param:    model.layers.N.layer.*   (ProgressiveModelDualPath 래핑)
+            # HF checkpoint: transformer.h.N.*         (Falcon 원본 형식)
+            if self.model_type == "falcon":
+                import re
+                falcon_name = re.sub(
+                    r'^model\.layers\.(\d+)\.layer\.',
+                    lambda m: f'transformer.h.{m.group(1)}.',
+                    param_name,
+                )
+                if falcon_name == param_name:
+                    # 레이어가 아닌 파라미터: embed_tokens, norm
+                    falcon_name = param_name \
+                        .replace("model.embed_tokens.", "transformer.word_embeddings.") \
+                        .replace("model.norm.", "transformer.ln_f.")
+                if falcon_name != param_name and falcon_name in checkpoint_weights:
+                    weight_loader = getattr(param, "weight_loader",
+                                           lambda p, w: p.data.copy_(w))
+                    weight_loader(param, checkpoint_weights[falcon_name])
+                    loaded_keys.add(param_name)
+                    loaded_count += 1
+                    continue
         
         # Missing weights 처리
         missing_keys = set(params_dict.keys()) - loaded_keys

--- a/progressive_serve/progressive_for_causal_lm.py
+++ b/progressive_serve/progressive_for_causal_lm.py
@@ -330,6 +330,29 @@ class ProgressiveForCausalLM(nn.Module):
                     loaded_keys.add(param_name)
                     loaded_count += 1
                     continue
+
+            # Option 5: Falcon HuggingFace 형식 변환
+            # vLLM param:    model.layers.N.layer.*   (ProgressiveModelDualPath 래핑)
+            # HF checkpoint: transformer.h.N.*         (Falcon 원본 형식)
+            if self.model_type == "falcon":
+                import re
+                falcon_name = re.sub(
+                    r'^model\.layers\.(\d+)\.layer\.',
+                    lambda m: f'transformer.h.{m.group(1)}.',
+                    param_name,
+                )
+                if falcon_name == param_name:
+                    # 레이어가 아닌 파라미터: embed_tokens, norm
+                    falcon_name = param_name \
+                        .replace("model.embed_tokens.", "transformer.word_embeddings.") \
+                        .replace("model.norm.", "transformer.ln_f.")
+                if falcon_name != param_name and falcon_name in checkpoint_weights:
+                    weight_loader = getattr(param, "weight_loader",
+                                           lambda p, w: p.data.copy_(w))
+                    weight_loader(param, checkpoint_weights[falcon_name])
+                    loaded_keys.add(param_name)
+                    loaded_count += 1
+                    continue
         
         # Missing weights 처리
         missing_keys = set(params_dict.keys()) - loaded_keys

--- a/progressive_serve/progressive_model_dual_path.py
+++ b/progressive_serve/progressive_model_dual_path.py
@@ -565,24 +565,45 @@ class ProgressiveModelDualPath(nn.Module):
         KV-only forward: norm → qkv_proj → rotary → write_kv_to_cache
         Attention 연산(softmax + o_proj) 및 MLP 실행 안 함.
 
-        지원: Llama, Mistral, Qwen2, Gemma 등 self_attn 패턴 모델
+        지원: Llama/Mistral (self_attn + input_layernorm),
+              Falcon (self_attention + input_layernorm or ln_attn)
         """
+        # Falcon 감지: self_attention 속성 존재 (Llama 계열은 self_attn 사용)
+        # falcon-7b:  parallel_attn + input_layernorm (단일 LN)
+        # falcon-40b+: parallel_attn + ln_attn + ln_mlp (이중 LN)
+        is_falcon = hasattr(layer, 'self_attention') and not hasattr(layer, 'self_attn')
+
         # 1. Input layernorm
-        if hasattr(layer, 'input_layernorm'):
+        if is_falcon:
+            if hasattr(layer, 'ln_attn'):
+                normed = layer.ln_attn(hidden_states)
+            else:
+                # falcon-7b: input_layernorm (단일 LN, parallel attn에서 shared)
+                normed = layer.input_layernorm(hidden_states)
+        elif hasattr(layer, 'input_layernorm'):
             if residual is None:
                 normed = layer.input_layernorm(hidden_states)
             else:
-                normed, _ = layer.input_layernorm(hidden_states, residual)
+                try:
+                    normed, _ = layer.input_layernorm(hidden_states, residual)
+                except TypeError:
+                    normed = layer.input_layernorm(hidden_states)
         else:
             normed = hidden_states
 
-        # 2. QKV projection + rotary + cache write
-        attn = getattr(layer, 'self_attn', None)
+        # 2. Attention 모듈 선택
+        if is_falcon:
+            attn = layer.self_attention
+        else:
+            attn = getattr(layer, 'self_attn', None)
         if attn is None:
             return
 
-        # qkv_proj
-        qkv_proj = getattr(attn, 'qkv_proj', None)
+        # 3. QKV projection
+        if is_falcon:
+            qkv_proj = getattr(attn, 'query_key_value', None)
+        else:
+            qkv_proj = getattr(attn, 'qkv_proj', None)
         if qkv_proj is None:
             return
 


### PR DESCRIPTION
- closes #33 
<br>

- Add Falcon HF key remap (Option 5) in progressive_for_causal_lm.load_weights.
- Apply the same remap logic to origin_progressive_serve/progressive_for_causal_lm.py.
- Extend progressive_model_dual_path KV-only path for Falcon (self_attention/query_key_value, ln_attn/input_layernorm fallback).